### PR TITLE
hotfix: wrong declaration of asm flag in the Makefile build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ OD     := $(PREFIX)objdump
 # flags
 CFLAGS   := -Wall -I $(INCDIR) -MMD -MP
 CXXFLAGS := -Wall -I $(INCDIR) -MMD -MP
-CXXFLAGS := -f elf
+ASMFLAGS := -f elf
 LDFLAGS  :=
 
 ifeq ($(DEBUG),1)


### PR DESCRIPTION
fixed:
- Makefile: not working for assembly code